### PR TITLE
fix(calendar): filter out events that already ended today

### DIFF
--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -203,8 +203,10 @@ export async function GET(request: NextRequest) {
       }),
     );
 
+    const now = new Date();
     const allEvents = feedResults
       .flatMap((f) => f.events)
+      .filter((e) => new Date(e.end) > now)
       .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime())
       .slice(0, limit);
 


### PR DESCRIPTION
## What

Events that have already ended today no longer show up in the Calendar widget. Previously the
event list was only sorted by date, without dropping events whose end time is in the past.

Filters by `end`, not `start`, so an event currently in progress still shows up correctly.

## Note

`feeds[].count` in the `/api/calendar` response now overcounts slightly (it's computed before this
filter runs). Checked — no frontend component reads `data.feeds` or `.count`, it's unused dead
weight that predates this change. Leaving it as-is to keep this PR minimal; flagging here in case
it's worth a follow-up cleanup.

## Testing

Verified manually against a real ICS feed via `docker compose up --build`: an event ended earlier
today, an event currently in progress, a later event today, and an event tomorrow. Confirmed
against the API response directly (not just visually) that only the ended one is filtered out.