### PR TITLE
Add option to hide control button for Home Assistant entities

### DIFF
--- a/src/app/editor/_inspectors/HomeAssistantInspector.tsx
+++ b/src/app/editor/_inspectors/HomeAssistantInspector.tsx
@@ -326,6 +326,20 @@ export default function HomeAssistantInspector({
           <span className="text-sm font-medium text-[var(--mf-fg)]/80 group-hover:text-[var(--mf-fg)] transition-colors">{t("Icon im Kasten")}</span>
         </label>
 
+        {/* Steuerungs-Button (Farbe/Slider) auf Kacheln ausblenden */}
+        <label className="flex items-center gap-3 cursor-pointer group py-2">
+          <div className="relative">
+            <input
+              type="checkbox"
+              checked={(activeWidget.config as any)?.hideControlButton === true}
+              onChange={(e) => updateConfig(activeWidget.i, "hideControlButton", e.target.checked)}
+              className="sr-only peer"
+            />
+            <div className="w-11 h-6 bg-[var(--mf-elev)]/10 rounded-full peer peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-500"></div>
+          </div>
+          <span className="text-sm font-medium text-[var(--mf-fg)]/80 group-hover:text-[var(--mf-fg)] transition-colors">{t("Steuerungs-Button ausblenden")}</span>
+        </label>
+
         <label className="text-sm font-medium text-[var(--mf-fg)]/80 mb-2 flex justify-between">
           <span>{t("Icon-Größe")}</span>
           <span className="text-blue-400">{Math.round(((activeWidget.config as any)?.iconScale ?? 1) * 100)}%</span>

--- a/src/app/editor/_types.ts
+++ b/src/app/editor/_types.ts
@@ -72,6 +72,7 @@ export interface WidgetLayoutItem {
     cardTheme?: 'dark' | 'light';
     cardBlur?: number;
     design?: 'cards' | 'minimal';
+    hideControlButton?: boolean;
     // #6 HA-triggered visibility (baseConfig)
     showWhenEntity?: string;
     showWhenState?: string;

--- a/src/components/widgets/HomeAssistantWidget.tsx
+++ b/src/components/widgets/HomeAssistantWidget.tsx
@@ -446,8 +446,8 @@ export default function HomeAssistantWidget({ config, onVisibilityChange }: { co
                        {unit && !['timer'].includes(domain) && <span style={{ fontSize: '0.6em' }}>{unit}</span>}
                     </div>
                 </div>
-                {(hasSlider || hasColorSupport) && (
-                   <button 
+                {(hasSlider || hasColorSupport) && !config?.hideControlButton && (
+                   <button
                      onClick={(e) => { e.stopPropagation(); setOpenColorModal(slot.id as string); }}
                      className={`shrink-0 w-[2.2em] h-[2.2em] rounded-full flex items-center justify-center ${isLight ? 'bg-black/5 text-black/60' : 'bg-white/10 text-white/60'} hover:scale-110 active:scale-95 transition-transform`}
                    >

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -237,6 +237,7 @@ export const EN: Record<string, string> = {
   "Icon mit Rahmen": "Icon with frame",
   "Icon-Größe": "Icon size",
   "Icon im Kasten": "Icon in box",
+  "Steuerungs-Button ausblenden": "Hide control button",
   "Kasten-Größe": "Box size",
   "Standard": "Default",
   "Standard (keine Farbe)": "Default (no color)",

--- a/src/lib/widgets/schemas.ts
+++ b/src/lib/widgets/schemas.ts
@@ -120,6 +120,7 @@ const homeAssistantConfig = baseConfig
     iconFrame: z.boolean().optional(), // Icon-Box an/aus (Default an)
     iconScale: z.number().optional(), // Icon-Größe-Faktor (Default 1)
     frameScale: z.number().optional(), // Kasten-Größe-Faktor (Default 1)
+    hideControlButton: z.boolean().optional(), // Steuerungs-Button (Farbe/Slider) auf Kacheln ausblenden
     entities: z.array(haEntitySlot).optional(),
   })
   .passthrough();


### PR DESCRIPTION
Allows the user to hide the control button for Home Assistant entities. Added a single toggle "Hide control button" in tile settings, which hides the control button for any entity (type). @jeremiaa @Closes #54.