### PR TITLE
feat(calendar): add Home Assistant calendar feeds

### DIFF
--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import ICAL from "ical.js";
 import { getSession } from "@/lib/auth/session";
-import { fetchGoogleEvents, fetchMicrosoftEvents } from "@/lib/calendar-auth/providers";
+import {
+  fetchGoogleEvents,
+  fetchMicrosoftEvents,
+  fetchHomeAssistantEvents,
+} from "@/lib/calendar-auth/providers";
 
 const cache = new Map<string, { data: any; timestamp: number }>();
 const CACHE_TTL = 10 * 60 * 1000;
@@ -10,7 +14,7 @@ type FeedInput = {
   id?: string;
   label?: string;
   color?: string;
-  type?: "ical" | "google" | "microsoft";
+  type?: "ical" | "google" | "microsoft" | "homeassistant";
   url?: string;
   accountId?: string;
   calendarId?: string;
@@ -266,6 +270,14 @@ export async function GET(request: NextRequest) {
               userId,
               accountId: feed.accountId,
               calendarId: feed.calendarId || "",
+              windowStart,
+              windowEnd,
+              limit: perFeedLimit,
+            });
+          } else if (type === "homeassistant") {
+            if (!feed.calendarId) throw new Error("missing_entityId");
+            events = await fetchHomeAssistantEvents({
+              entityId: feed.calendarId,
               windowStart,
               windowEnd,
               limit: perFeedLimit,

--- a/src/app/editor/_inspectors/CalendarInspector.tsx
+++ b/src/app/editor/_inspectors/CalendarInspector.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import type { WidgetLayoutItem } from '../_types';
 import { useT } from "@/lib/i18n/LocaleProvider";
+import HAEntityInput from "../_components/HAEntityInput";
 
 type CalendarInspectorProps = {
   widget: WidgetLayoutItem;
@@ -157,7 +158,7 @@ export default function CalendarInspector({
   );
 }
 
-type FeedType = "ical" | "google" | "microsoft";
+type FeedType = "ical" | "google" | "microsoft" | "homeassistant";
 
 type Feed = {
   id?: string;
@@ -293,6 +294,7 @@ function FeedsEditor({
               <option value="ical">{t("iCal / Webcal")}</option>
               <option value="google">{t("Google-Konto")}</option>
               <option value="microsoft">Microsoft 365</option>
+              <option value="homeassistant">Home Assistant</option>
             </select>
             <FeedBody
               feed={feed}
@@ -307,7 +309,7 @@ function FeedsEditor({
         </div>
       ))}
 
-      <div className="grid grid-cols-3 gap-2">
+      <div className="grid grid-cols-4 gap-2">
         <button
           onClick={() =>
             write([
@@ -361,6 +363,23 @@ function FeedsEditor({
         >
           + Microsoft
         </button>
+        <button
+          onClick={() =>
+            write([
+              ...feeds,
+              {
+                id: `feed-${Date.now()}`,
+                label: "Home Assistant",
+                type: "homeassistant",
+                calendarId: "",
+                color: "#10B981",
+              },
+            ])
+          }
+          className="h-9 text-xs font-medium text-[var(--mf-fg)]/70 hover:text-[var(--mf-fg)] border border-dashed border-[var(--mf-bdr)]/15 hover:border-emerald-500/40 rounded-md transition-colors"
+        >
+          + HA
+        </button>
       </div>
     </div>
   );
@@ -383,6 +402,18 @@ function FeedBody({
         placeholder="https://p01-calendars.icloud.com/…"
         onChange={(e) => onChange({ url: e.target.value })}
         className="flex-1 bg-[var(--mf-surface)] border border-[var(--mf-bdr)]/10 text-[var(--mf-fg)]/80 text-xs font-mono rounded-md px-3 h-9 focus:outline-none focus:border-violet-500"
+      />
+    );
+  }
+
+  if (feed.type === "homeassistant") {
+    return (
+      <HAEntityInput
+        value={feed.calendarId ?? ""}
+        onChange={(entityId) => onChange({ calendarId: entityId })}
+        domains={["calendar"]}
+        placeholder="calendar.familie"
+        className="flex-1 bg-[var(--mf-surface)] border border-[var(--mf-bdr)]/10 text-[var(--mf-fg)]/80 text-xs font-mono rounded-md px-3 h-9 focus:outline-none focus:border-emerald-500"
       />
     );
   }

--- a/src/components/widgets/CalendarWidget.tsx
+++ b/src/components/widgets/CalendarWidget.tsx
@@ -19,7 +19,7 @@ type FeedConfig = {
   id?: string;
   label?: string;
   color?: string;
-  type?: "ical" | "google" | "microsoft";
+  type?: "ical" | "google" | "microsoft" | "homeassistant";
   url?: string;
   accountId?: string;
   calendarId?: string;
@@ -29,6 +29,7 @@ const isValidFeed = (f: any): boolean => {
   if (!f || typeof f !== "object") return false;
   const type = f.type ?? "ical";
   if (type === "ical") return typeof f.url === "string" && f.url.trim() !== "";
+  if (type === "homeassistant") return typeof f.calendarId === "string" && f.calendarId.trim() !== "";
   return typeof f.accountId === "string" && f.accountId.trim() !== "";
 };
 

--- a/src/lib/calendar-auth/providers.ts
+++ b/src/lib/calendar-auth/providers.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { getFreshAccessToken } from "./store";
+import { getAppSettings } from "@/lib/settings/store";
 
 export type ProviderEvent = {
   id: string;
@@ -147,4 +148,57 @@ export async function fetchMicrosoftCalendars(params: {
     primary: !!c.isDefaultCalendar,
     backgroundColor: c.hexColor,
   }));
+}
+
+// Home Assistant has no per-user OAuth account — the same global haUrl/haToken
+// from Integrations (see src/app/api/ha/entities/route.ts) is used for every
+// feed, keyed by the calendar entity id instead of an accountId.
+export async function fetchHomeAssistantEvents(params: {
+  entityId: string;
+  windowStart: Date;
+  windowEnd: Date;
+  limit: number;
+}): Promise<ProviderEvent[]> {
+  const settings = await getAppSettings();
+  if (!settings.haUrl || !settings.haToken) throw new Error("ha_not_configured");
+
+  const base = settings.haUrl.replace(/\/+$/, "");
+  const url = new URL(`${base}/api/calendars/${encodeURIComponent(params.entityId)}`);
+  url.searchParams.set("start", params.windowStart.toISOString());
+  url.searchParams.set("end", params.windowEnd.toISOString());
+
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${settings.haToken}` },
+    cache: "no-store",
+    signal: AbortSignal.timeout(8000),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`ha_http_${res.status}:${body.slice(0, 120)}`);
+  }
+  const items = await res.json();
+  if (!Array.isArray(items)) return [];
+
+  // HA serializes CalendarEvent.start/end as either {dateTime: "..."} for
+  // timed events or {date: "YYYY-MM-DD"} for all-day ones (same shape as the
+  // Google feed above) — but older/customized integrations have been known
+  // to return a plain ISO string instead of the nested object, so accept both.
+  const pick = (v: any): { value: string | null; isDate: boolean } => {
+    if (typeof v === "string") return { value: v, isDate: false };
+    if (v?.dateTime) return { value: v.dateTime, isDate: false };
+    if (v?.date) return { value: `${v.date}T00:00:00`, isDate: true };
+    return { value: null, isDate: false };
+  };
+
+  return items.slice(0, params.limit).map((ev: any) => {
+    const start = pick(ev.start);
+    const end = pick(ev.end);
+    return {
+      id: ev.uid || `${params.entityId}-${start.value ?? Math.random()}`,
+      title: ev.summary ?? "(no title)",
+      start: start.value ? new Date(start.value).toISOString() : new Date().toISOString(),
+      end: end.value ? new Date(end.value).toISOString() : new Date().toISOString(),
+      isAllDay: start.isDate,
+    };
+  });
 }


### PR DESCRIPTION
## Summary
- Adds a `homeassistant` calendar feed type alongside the existing iCal/Google/Microsoft ones, so calendars already surfaced in Home Assistant (Google, iCal, mealie.io, etc.) can be pulled into a Calendar widget the same way.
- Reuses the global HA URL/token already configured on the Integrations page (same connection used by the HA entity pickers, notifications, and `todo.*` lists) instead of a new per-user OAuth flow — there's nothing extra to configure.
- Calendar selection reuses the existing `HAEntityInput` autocomplete, filtered to `calendar.*` entities.
- Events are fetched from Home Assistant's `GET /api/calendars/<entity_id>?start=&end=` REST endpoint, which handles recurrence expansion server-side.

Closes #65

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] Manually verified in a running instance: added a Home Assistant feed in the Calendar widget inspector, selected a `calendar.*` entity with real events, confirmed events render in the widget
- [x] Fixed a related client-side bug found during manual testing: `CalendarWidget`'s feed-validity check only recognized `url` (iCal) or `accountId` (Google/Microsoft) as "configured", so Home Assistant feeds (which only set `calendarId`) were silently dropped before ever calling the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLHivppTaMA6DzUYiX9Ywc