### PR TITLE
feat: pop-up / modal overlays — fit more controls onto small wall panels

### DIFF
--- a/src/app/editor/_components/InspectorPanel.tsx
+++ b/src/app/editor/_components/InspectorPanel.tsx
@@ -423,6 +423,14 @@ function LayoutTab({
               </>
             )}
           </div>
+          {activeWidget.type === "ButtonWidget.tsx" && (
+            <Toggle
+              label="Tippen außerhalb der Buttons schließt das Widget"
+              checked={activeWidget.config?.hideOnOutsideTap ?? false}
+              onChange={(v) => updateConfig(activeWidget.i, "hideOnOutsideTap", v)}
+              accent="purple"
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/app/editor/_inspectors/ButtonInspector.tsx
+++ b/src/app/editor/_inspectors/ButtonInspector.tsx
@@ -280,6 +280,47 @@ function ActionEditor({
           />
         </div>
       )}
+
+      {/* Self-hide: after the action, hide this whole button widget. The
+          building block for closing a pop-up — a close button that hides the
+          panel (its main action) and then removes itself. */}
+      <div>
+        <label className="flex items-center justify-between gap-3 cursor-pointer group">
+          <span className="text-xs font-medium text-[var(--mf-fg)]/70">
+            {t("Dieses Widget nach der Aktion ausblenden")}
+          </span>
+          <div className="relative">
+            <input
+              type="checkbox"
+              checked={!!(activeWidget.config as any)?.[k("selfHide")]}
+              onChange={(e) => updateConfig(activeWidget.i, k("selfHide"), e.target.checked)}
+              className="sr-only peer"
+            />
+            <div className="w-9 h-5 bg-[var(--mf-elev)]/10 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-indigo-500"></div>
+          </div>
+        </label>
+        {!!(activeWidget.config as any)?.[k("selfHide")] && (
+          <div className="mt-3">
+            <div className="flex justify-between mb-2">
+              <label className="text-xs font-medium text-[var(--mf-fg)]/70">{t("Verzögerung vor dem Ausblenden")}</label>
+              <span className="text-xs text-indigo-400">
+                {((activeWidget.config as any)?.[k("selfHideDelay")] ?? 0) === 0
+                  ? t("Sofort")
+                  : `${(activeWidget.config as any)?.[k("selfHideDelay")]}s`}
+              </span>
+            </div>
+            <input
+              type="range"
+              min="0"
+              max="10"
+              step="0.5"
+              value={(activeWidget.config as any)?.[k("selfHideDelay")] ?? 0}
+              onChange={(e) => updateConfig(activeWidget.i, k("selfHideDelay"), parseFloat(e.target.value))}
+              className="w-full accent-indigo-500"
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/editor/_types.ts
+++ b/src/app/editor/_types.ts
@@ -19,6 +19,9 @@ export interface WidgetLayoutItem {
   responsiveText?: boolean;
   defaultHidden?: boolean;
   floatingCard?: boolean;
+  // Buttons widget as a modal overlay: a tap on the widget's area but outside
+  // any button hides the whole widget (backdrop-to-dismiss).
+  hideOnOutsideTap?: boolean;
   showHumidity?: boolean;
   showWind?: boolean;
   showUv?: boolean;

--- a/src/app/view/[id]/page.tsx
+++ b/src/app/view/[id]/page.tsx
@@ -602,6 +602,8 @@ export default function DashboardView({ params }: { params: Promise<{ id: string
   const renderWidgetContent = (type: string, config: any, id: string) =>
     renderWidget(type, config, {
       dashboardId,
+      // Passed so a Buttons widget can hide itself after acting (pop-up close).
+      widgetId: id,
       onVisibilityChange: (isVisible) =>
         setAutoHiddenWidgets(prev => prev[id] === !isVisible ? prev : { ...prev, [id]: !isVisible }),
       // #41: soll diese Kamera gerade im Vollbild stehen? Der View rechnet das

--- a/src/app/view/[id]/page.tsx
+++ b/src/app/view/[id]/page.tsx
@@ -683,12 +683,20 @@ export default function DashboardView({ params }: { params: Promise<{ id: string
              const floating = edgeToEdge && w.config?.floatingCard === true;
              const justifyClass = isCardBased ? 'justify-start' : 'justify-center';
 
+             // Hidden = fully transparent AND click-through. The
+             // pointer-events-none MUST also sit on the outer react-grid-item
+             // wrapper: it covers the cell absolutely and would otherwise catch
+             // every tap even though nothing is visible — exactly what blocked a
+             // button UNDER a hidden full-screen widget (the pop-up case).
+             const isHidden = userHiddenWidgets[w.i] || autoHiddenWidgets[w.i] || triggerHiddenWidgets[w.i];
+
               return (
                <div
                  key={w.i}
+                 className={isHidden ? 'pointer-events-none' : undefined}
                  style={{ zIndex: typeof w.config?.zIndex === "number" ? w.config.zIndex : index }}
                >
-                 <div className={`w-full h-full flex ${justifyClass} flex-col ${paddingClass} rounded-3xl overflow-hidden transition-opacity duration-500 ${(userHiddenWidgets[w.i] || autoHiddenWidgets[w.i] || triggerHiddenWidgets[w.i]) ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}
+                 <div className={`w-full h-full flex ${justifyClass} flex-col ${paddingClass} rounded-3xl overflow-hidden transition-opacity duration-500 ${isHidden ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}
                       style={{
                         containerType: 'size',
                         // Randlos-Modus: eckige Kacheln (CSS-Var vom Canvas);

--- a/src/components/widgets/ButtonWidget.tsx
+++ b/src/components/widgets/ButtonWidget.tsx
@@ -7,18 +7,40 @@ import { haAction } from "@/lib/ha/action-client";
 
 interface ButtonWidgetProps {
   config?: any;
+  // Layout id of this button widget, so a slot can hide the widget itself
+  // after acting. Undefined in the editor preview (buttons don't fire there).
+  widgetId?: string;
 }
 
 const LONG_PRESS_MS = 500;
 
-async function runButtonAction(slot: any, longPress: boolean) {
+// Runs the slot's chosen action, then optionally hides THIS button widget so a
+// button can close what it opened — e.g. a close button laid over a pop-up that
+// hides the panel and then removes itself. Self-hide reuses the same
+// WIDGET_ACTION → hide path the view already handles; the target is the button's
+// own layout id (selfId), passed down from the view. Honours an optional delay
+// (seconds) so the button can linger briefly before it disappears.
+async function runButtonAction(slot: any, longPress: boolean, selfId?: string) {
+    const action = longPress ? (slot.longPressAction || "none") : (slot.actionType || "toggle");
+    await performButtonAction(slot, action, longPress);
+
+    const selfHide = longPress ? slot.longPressSelfHide : slot.selfHide;
+    if (selfHide && selfId) {
+        const delaySec = Math.max(0, Number(longPress ? slot.longPressSelfHideDelay : slot.selfHideDelay) || 0);
+        const hideSelf = () =>
+            window.dispatchEvent(new CustomEvent("WIDGET_ACTION", { detail: { targets: [selfId], actionType: "hide" } }));
+        if (delaySec > 0) setTimeout(hideSelf, delaySec * 1000);
+        else hideSelf();
+    }
+}
+
+async function performButtonAction(slot: any, action: string, longPress: boolean) {
     // actionType Varianten:
     //  'toggle' | 'show' | 'hide'  -> CustomEvent an Widget-Targets
     //  'ha_service'                -> HA-Service-Call (/api/ha/action)
     //  'ha_toggle'                 -> HA-toggle auf bestimmter Entity
     //  'webhook'                   -> fetch POST
     //  'none'                      -> nix
-    const action = longPress ? (slot.longPressAction || "none") : (slot.actionType || "toggle");
 
     if (action === "none") return;
 
@@ -84,7 +106,7 @@ async function runButtonAction(slot: any, longPress: boolean) {
 
 const ActionBtn = ({
     icon, label, slot, customColor, responsiveText, iconSize, fontSize,
-    bgOpacity, bgBlur, bgRadius, btnShape, iconScale = 100, btnScale = 100
+    bgOpacity, bgBlur, bgRadius, btnShape, iconScale = 100, btnScale = 100, widgetId
 }: any) => {
     // btnShape: "square" | "circle" | "subtle" | "fill"
     const shape = btnShape || 'square';
@@ -97,11 +119,13 @@ const ActionBtn = ({
 
     const startLongPressTimer = () => {
         longPressFired.current = false;
-        if (!slot?.longPressAction || slot.longPressAction === "none") return;
+        // Also arm the timer when the long press only self-hides (action "none"),
+        // otherwise a long-press-to-dismiss button would never fire.
+        if ((!slot?.longPressAction || slot.longPressAction === "none") && !slot?.longPressSelfHide) return;
         longPressTimer.current = setTimeout(() => {
             longPressFired.current = true;
             if (navigator.vibrate) navigator.vibrate(25);
-            runButtonAction(slot, true);
+            runButtonAction(slot, true, widgetId);
         }, LONG_PRESS_MS);
     };
     const cancelLongPressTimer = () => {
@@ -113,7 +137,7 @@ const ActionBtn = ({
 
     const handleClick = () => {
         if (longPressFired.current) return;
-        runButtonAction(slot, false);
+        runButtonAction(slot, false, widgetId);
     };
 
     const hasBox = bgOpacity > 0 || bgBlur > 0;
@@ -221,7 +245,7 @@ const ActionBtn = ({
     );
 };
 
-export default function ButtonWidget({ config = {} }: ButtonWidgetProps) {
+export default function ButtonWidget({ config = {}, widgetId }: ButtonWidgetProps) {
   const t = useT();
 
   // Extract up to 4 configured buttons.
@@ -268,6 +292,12 @@ export default function ButtonWidget({ config = {} }: ButtonWidgetProps) {
           longPressServiceData:
             config[`longPressHaServiceData${suffix}`] ?? config[`longPressServiceData${suffix}`],
           longPressWebhook: config[`longPressWebhook${suffix}`],
+          // "Hide this widget" — after the action, hide the whole button widget
+          // (the pop-up close helper). Separate flag + delay per press type.
+          selfHide: !!config[`selfHide${suffix}`],
+          selfHideDelay: config[`selfHideDelay${suffix}`],
+          longPressSelfHide: !!config[`longPressSelfHide${suffix}`],
+          longPressSelfHideDelay: config[`longPressSelfHideDelay${suffix}`],
           customColor: config[`color${suffix}`] || config.color
       };
   };
@@ -328,6 +358,7 @@ export default function ButtonWidget({ config = {} }: ButtonWidgetProps) {
                   iconScale={config.iconScale}
                   btnScale={config.btnScale}
                   btnShape={config.btnShape}
+                  widgetId={widgetId}
                />
             ))}
         </div>

--- a/src/components/widgets/ButtonWidget.tsx
+++ b/src/components/widgets/ButtonWidget.tsx
@@ -169,6 +169,7 @@ const ActionBtn = ({
     return (
         <div style={overrideStyle} className="flex items-center justify-center p-2 group">
             <div
+               data-mf-button
                className={`relative flex flex-col items-center justify-center cursor-pointer transition-all duration-300 ${shape !== 'subtle' ? 'shadow-lg' : 'group-hover:bg-white/5 rounded-xl'} ${isPressing ? 'scale-90 opacity-50 bg-white/30' : 'opacity-80'}`}
                style={{...bgStyle, touchAction: 'manipulation', WebkitTapHighlightColor: 'transparent'}}
 
@@ -309,8 +310,18 @@ export default function ButtonWidget({ config = {}, widgetId }: ButtonWidgetProp
   const designLayout = config.designLayout || 'auto';
   const bgOpacity = config.bgOpacity !== undefined ? Number(config.bgOpacity) : 5;
   const bgBlur = config.bgBlur !== undefined ? Number(config.bgBlur) : 10;
-  const bgRadius = config.bgRadius !== undefined ? Number(config.bgRadius) : 50; 
-  
+  const bgRadius = config.bgRadius !== undefined ? Number(config.bgRadius) : 50;
+
+  // Tap on the widget's own area but NOT on a button hides the whole widget —
+  // the "tap outside to dismiss" of a modal overlay. Buttons carry a
+  // data-mf-button marker, so a tap that lands on one is ignored here.
+  const hideOnOutsideTap = !!config.hideOnOutsideTap;
+  const handleBackdropTap = (e: React.MouseEvent) => {
+    if (!hideOnOutsideTap || !widgetId) return;
+    if ((e.target as HTMLElement).closest?.("[data-mf-button]")) return;
+    window.dispatchEvent(new CustomEvent("WIDGET_ACTION", { detail: { targets: [widgetId], actionType: "hide" } }));
+  };
+
   if (activeBtns.length === 0) {
       // Fallback for completely empty configuration
       return (
@@ -337,9 +348,10 @@ export default function ButtonWidget({ config = {}, widgetId }: ButtonWidgetProp
   }
 
   return (
-    <div 
+    <div
       className="relative w-full h-full p-2 lg:p-4"
       style={{ containerType: 'size' }}
+      onClick={handleBackdropTap}
     >
         <div className={gridStyle}>
             {activeBtns.map(btn => (

--- a/src/components/widgets/renderWidget.tsx
+++ b/src/components/widgets/renderWidget.tsx
@@ -38,12 +38,18 @@ export type RenderWidgetOpts = {
   openFullscreen?: boolean;
   /** Laufende Nummer des Vollbild-Befehls — siehe CameraWidget. */
   fullscreenSeq?: number;
+  /**
+   * The layout id (w.i) of the widget being rendered. Passed to widgets that
+   * need to act on themselves — the Buttons widget uses it to hide itself after
+   * running an action (the "close pop-up" building block).
+   */
+  widgetId?: string;
 };
 
 export function renderWidget(type: string, config: any, opts: RenderWidgetOpts = {}): React.ReactNode {
-  const { dashboardId, onVisibilityChange, openFullscreen, fullscreenSeq } = opts;
+  const { dashboardId, onVisibilityChange, openFullscreen, fullscreenSeq, widgetId } = opts;
   if (type === "ClockWidget.tsx") return <ClockWidget config={config} />;
-  if (type === "ButtonWidget.tsx") return <ButtonWidget config={config} />;
+  if (type === "ButtonWidget.tsx") return <ButtonWidget config={config} widgetId={widgetId} />;
   if (type === "TimerWidget.tsx") return <TimerWidget config={config} dashboardId={dashboardId} />;
   if (type === "MessagesWidget.tsx") return <MessagesWidget config={config} dashboardId={dashboardId} />;
   if (type === "ShoppingListWidget.tsx") return <ShoppingListWidget config={config} />;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -2156,6 +2156,7 @@ export const EN: Record<string, string> = {
     "Some of these cannot be read by this account — they need an administrator role, so what you see here is incomplete.",
   "Ein Kalender antwortet nicht": "A calendar is not answering",
   "Dieses Widget nach der Aktion ausblenden": "Hide this widget after action",
+  "Tippen außerhalb der Buttons schließt das Widget": "Tap outside the buttons to close",
   "Verzögerung vor dem Ausblenden": "Delay before hiding",
   "Sofort": "Immediately",
 };

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -2155,4 +2155,7 @@ export const EN: Record<string, string> = {
   "Einige dieser Werte kann dieses Konto nicht abrufen — sie brauchen eine Administrator-Rolle. Was hier steht, ist deshalb unvollständig.":
     "Some of these cannot be read by this account — they need an administrator role, so what you see here is incomplete.",
   "Ein Kalender antwortet nicht": "A calendar is not answering",
+  "Dieses Widget nach der Aktion ausblenden": "Hide this widget after action",
+  "Verzögerung vor dem Ausblenden": "Delay before hiding",
+  "Sofort": "Immediately",
 };

--- a/wiki/stacking-and-visibility.md
+++ b/wiki/stacking-and-visibility.md
@@ -223,36 +223,56 @@ Consequences that matter:
   underneath is visible instead.
 - **Taps pass straight through it.** A hidden widget no longer catches the tap,
   so whatever sits underneath — a button, a tile, anything — is fully clickable
-  through it, exactly as if the hidden widget were not there. This is what makes
-  real pop-ups possible (below).
+  through it, exactly as if the hidden widget were not there. This is what lets a
+  hidden overlay sit on top of a view without blocking it (see
+  [Pop-ups and modal overlays](#pop-ups-and-modal-overlays)).
 - **Showing and hiding fades over half a second.** There is no way to turn the
   fade off.
 - **Hidden is not remembered.** Visibility lives in the open page: reload the
   display and everything is back to how the layout says it starts.
 
-## Real pop-ups: a full-screen panel a hidden button reveals
+## Pop-ups and modal overlays
 
-Because a hidden widget lets taps fall through to whatever is underneath, you can
-stack a large — even full-view — widget on top of a button, start it hidden, and
-have the button bring it up on demand. While the panel is hidden the button
-underneath is live; tap it and the panel appears over everything.
+A **Buttons** widget can be laid over the rest of a view, kept hidden until
+something opens it, and used as a **pop-up / modal overlay** — a panel of buttons
+that appears on top of everything, does its job, and disappears again. Two
+behaviours make this practical:
 
-1. Place the widget you want as the pop-up — a **Kamera** (Camera), a big
-   **Home Assistant** panel, an **Image**, whatever — over the area it should
-   cover. Give it a high enough layer that it sits in front (drag it up the
-   layer list).
-2. Select it, open the inspector's **Layout** tab, and switch on **Beim Laden
-   versteckt** (Hidden on load). While hidden it is invisible *and* lets taps
-   through to whatever is below.
-3. Place a **Buttons** widget in the cells the pop-up covers — it stays reachable
-   through the hidden panel — and point one button at the pop-up with the
-   **show** or **toggle** action (see [above](#the-actions-a-button-can-run)).
-4. Press **Speichern** (Save).
+- A hidden widget lets taps fall through it (above), so the overlay sitting on
+  top of the view blocks nothing while it is closed.
+- A button can **hide its own widget after acting**, so a button inside the
+  overlay can close the overlay.
 
-Tapping the button now raises the pop-up. To dismiss it, give the pop-up its own
-close control — for example a small **Buttons** widget stacked *on top of* the
-pop-up (higher layer) running a **hide** action on it, so the ✕ stays tappable
-while the panel is up.
+### Building the overlay
+
+1. Add a **Buttons** widget and size it over the area the overlay should cover —
+   up to the whole screen. Drag it up the layer list so it sits in front of what
+   it overlaps.
+2. Fill in its buttons (up to four) with whatever the overlay should offer —
+   scenes, lights, a webhook, a page reload, or plain show/hide of other widgets.
+3. Select the widget, open the inspector's **Layout** tab, and switch on **Beim
+   Laden versteckt** (Hidden on load). The overlay now starts closed, and while
+   hidden it lets taps through to the view underneath.
+4. On any button that should dismiss the overlay, switch on **Dieses Widget nach
+   der Aktion ausblenden** (Hide this widget after action): the button runs its
+   action and then hides the whole overlay. An optional **Verzögerung** (delay,
+   in seconds) lets it wait first. Put this on a dedicated "close" button, or on
+   every button so the overlay closes itself once a choice is made.
+5. Press **Speichern** (Save).
+
+### Opening the overlay
+
+Since the overlay starts hidden, something has to show it. Anything that can run
+a **show** or **toggle** action works:
+
+- **A button on the view** — an always-visible button (say, a small menu icon)
+  with a **show** action pointed at the overlay.
+- **A Home Assistant entity** — via the Buttons widget's **Auto** tab, so an
+  entity opens the overlay on its own (see
+  [Letting Home Assistant press a button](#letting-home-assistant-press-a-button)).
+
+The trigger shows the overlay; a button inside it, with **Hide this widget after
+action**, closes it again.
 
 ## The three switches, and the trap
 

--- a/wiki/stacking-and-visibility.md
+++ b/wiki/stacking-and-visibility.md
@@ -221,10 +221,38 @@ Consequences that matter:
   hiding a widget saves nothing on a slow display.
 - **It still occupies its cells**, but as it is transparent, whatever is
   underneath is visible instead.
+- **Taps pass straight through it.** A hidden widget no longer catches the tap,
+  so whatever sits underneath — a button, a tile, anything — is fully clickable
+  through it, exactly as if the hidden widget were not there. This is what makes
+  real pop-ups possible (below).
 - **Showing and hiding fades over half a second.** There is no way to turn the
   fade off.
 - **Hidden is not remembered.** Visibility lives in the open page: reload the
   display and everything is back to how the layout says it starts.
+
+## Real pop-ups: a full-screen panel a hidden button reveals
+
+Because a hidden widget lets taps fall through to whatever is underneath, you can
+stack a large — even full-view — widget on top of a button, start it hidden, and
+have the button bring it up on demand. While the panel is hidden the button
+underneath is live; tap it and the panel appears over everything.
+
+1. Place the widget you want as the pop-up — a **Kamera** (Camera), a big
+   **Home Assistant** panel, an **Image**, whatever — over the area it should
+   cover. Give it a high enough layer that it sits in front (drag it up the
+   layer list).
+2. Select it, open the inspector's **Layout** tab, and switch on **Beim Laden
+   versteckt** (Hidden on load). While hidden it is invisible *and* lets taps
+   through to whatever is below.
+3. Place a **Buttons** widget in the cells the pop-up covers — it stays reachable
+   through the hidden panel — and point one button at the pop-up with the
+   **show** or **toggle** action (see [above](#the-actions-a-button-can-run)).
+4. Press **Speichern** (Save).
+
+Tapping the button now raises the pop-up. To dismiss it, give the pop-up its own
+close control — for example a small **Buttons** widget stacked *on top of* the
+pop-up (higher layer) running a **hide** action on it, so the ✕ stays tappable
+while the panel is up.
 
 ## The three switches, and the trap
 

--- a/wiki/stacking-and-visibility.md
+++ b/wiki/stacking-and-visibility.md
@@ -235,13 +235,15 @@ Consequences that matter:
 
 A **Buttons** widget can be laid over the rest of a view, kept hidden until
 something opens it, and used as a **pop-up / modal overlay** — a panel of buttons
-that appears on top of everything, does its job, and disappears again. Two
+that appears on top of everything, does its job, and disappears again. Three
 behaviours make this practical:
 
 - A hidden widget lets taps fall through it (above), so the overlay sitting on
   top of the view blocks nothing while it is closed.
 - A button can **hide its own widget after acting**, so a button inside the
-  overlay can close the overlay.
+  overlay can close it once a choice is made.
+- The overlay can **close on a tap outside its buttons**, so it can be dismissed
+  without choosing anything — the escape hatch when it was opened by mistake.
 
 ### Building the overlay
 
@@ -253,12 +255,7 @@ behaviours make this practical:
 3. Select the widget, open the inspector's **Layout** tab, and switch on **Beim
    Laden versteckt** (Hidden on load). The overlay now starts closed, and while
    hidden it lets taps through to the view underneath.
-4. On any button that should dismiss the overlay, switch on **Dieses Widget nach
-   der Aktion ausblenden** (Hide this widget after action): the button runs its
-   action and then hides the whole overlay. An optional **Verzögerung** (delay,
-   in seconds) lets it wait first. Put this on a dedicated "close" button, or on
-   every button so the overlay closes itself once a choice is made.
-5. Press **Speichern** (Save).
+4. Press **Speichern** (Save).
 
 ### Opening the overlay
 
@@ -271,8 +268,21 @@ a **show** or **toggle** action works:
   entity opens the overlay on its own (see
   [Letting Home Assistant press a button](#letting-home-assistant-press-a-button)).
 
-The trigger shows the overlay; a button inside it, with **Hide this widget after
-action**, closes it again.
+### Closing the overlay
+
+Two ways to dismiss it — use either, or both:
+
+- **A button that closes after acting.** In a button's action settings (its
+  **Btn** tab), switch on **Dieses Widget nach der Aktion ausblenden** (Hide this
+  widget after action): the button runs its action and then hides the whole
+  overlay. An optional **Verzögerung** (delay, in seconds) lets it wait first. Put
+  it on a dedicated "close" button, or on every button so the overlay dismisses
+  itself once a choice is made. It works the same on a long press.
+- **A tap outside the buttons.** In the **Layout** tab, under **Sichtbarkeit**
+  (Visibility), switch on **Tippen außerhalb der Buttons schließt das Widget**
+  (Tap outside the buttons to close). Now a tap anywhere on the overlay that is
+  not a button closes it — the usual "tap the backdrop to dismiss" of a modal.
+  Size the widget to cover the whole view and this becomes a full-screen backdrop.
 
 ## The three switches, and the trap
 


### PR DESCRIPTION
## Why

Small wall panels are wonderful but cramped. On a **Sonoff NSPanel Pro (480×480)**
there just isn't room to lay out every scene, light, cover and sensor at once — a
board that fits also has to stay readable from across the room. You end up
choosing between a clean glanceable display and having your controls one tap away.

Overlays solve that. A **Buttons** widget can sit hidden on top of the view and
pop up on demand as a **modal panel**, so the base screen stays calm — clock,
weather, the two things you actually want to see — while a whole grid of controls
is one tap away and gone again the moment you're done. On a 480×480 panel this
effectively multiplies the usable surface: several full "pages" of buttons living
on one view, each summoned when needed.


This already almost worked with the existing stack/hide features — three small
gaps were in the way. This PR closes them.

## What this adds

1. **Hidden widgets are click-through.** A hidden widget dropped `pointer-events`
   on its inner content, but the outer `react-grid-item` wrapper covering the cell
   kept `pointer-events: auto` and swallowed every tap — so a hidden panel blocked
   whatever sat beneath it. Now the hidden state reaches the wrapper too, and taps
   fall straight through to the widget below. (This is what makes an overlay you
   can leave "parked" on top of the view viable at all.)

2. **A button can hide its own widget after acting.** New per-button option
   *Hide this widget after action* (optional delay; works on tap and long press).
   The button runs its action, then hides the whole widget it lives in — so a
   control inside an overlay closes the overlay as it fires.

3. **Tap outside the buttons to close.** New Buttons-widget option in
   Layout → Visibility. A tap on the widget's area that doesn't land on a button
   dismisses the overlay — the familiar "tap the backdrop" of a modal, and the
   escape hatch when it was opened by mistake.

## Example: two control drawers on a 480×480 panel

https://github.com/user-attachments/assets/0c2ebb44-9a5f-4e77-91cd-22946c50733c

A Sonoff NSPanel Pro (480×480): weather on top, two triggers — **Gate** and
**Vacuum** — below. Each opens a hidden Buttons overlay (Gate → *Open* / *Hold*;
Vacuum → *All rooms* / *Living room* / *Kitchen* / *Bedroom*). Every option fires
its Home Assistant action and closes the drawer in the same tap. Six controls on a
panel that shows two at rest.

## Implementation notes

- The live view passes each widget its own layout id; the Buttons widget uses it
  to target itself through the existing `WIDGET_ACTION → hide` path — no new
  view-side plumbing.
- Buttons carry a `data-mf-button` marker so the backdrop-tap handler can tell a
  button tap from a background tap.
- New config (`selfHide` / `selfHideDelay` + `longPress*` variants,
  `hideOnOutsideTap`) rides the Buttons widget's existing `passthrough` schema, so
  it survives save / duplicate / rename like every other slot field. No schema
  migration.

## Docs

`wiki/stacking-and-visibility.md` gains a **Pop-ups and modal overlays** section
(building, opening, and both ways of closing), and the "hidden" explanation now
notes that taps pass through.

## Compatibility

No behaviour change for existing layouts: all new options default off, and the
click-through fix only affects widgets that are already hidden (which were already
meant not to respond to taps).

## Notes

- I've tried to follow the existing code style and conventions throughout.
- I kept the new UI strings bilingual through the i18n system (German source +
  English in `en.ts`) — the German is AI-assisted, so please double-check that
  those translations read naturally.